### PR TITLE
feat(renderer|env): Add option `enable_exec`

### DIFF
--- a/.dukkha.yaml
+++ b/.dukkha.yaml
@@ -36,6 +36,8 @@ renderers:
   http:
     enable_cache: true
     cache_max_age: 10s
+  env:
+    enable_exec: true
 
 shells:
 - name: bash

--- a/docs/generated/schema.json
+++ b/docs/generated/schema.json
@@ -893,8 +893,8 @@
         },
         "default_git_branch": {
           "type": "string",
-          "description": "set GIT_DEFAULT_BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)",
-          "x-intellij-html-description": "set GIT<em>DEFAULT</em>BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)"
+          "description": "set GIT_DEFAULT_BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)  If your have multiple definitions of this option in different config file, only the first occurrence of the option is used.",
+          "x-intellij-html-description": "set GIT<em>DEFAULT</em>BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)  If your have multiple definitions of this option in different config file, only the first occurrence of the option is used."
         },
         "env": {
           "$ref": "#/definitions/arhat.dev.dukkha.pkg.dukkha.Env",
@@ -925,8 +925,8 @@
         },
         "^default_git_branch@.*": {
           "type": "string",
-          "description": "set GIT_DEFAULT_BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)",
-          "x-intellij-html-description": "set GIT<em>DEFAULT</em>BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)"
+          "description": "set GIT_DEFAULT_BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)  If your have multiple definitions of this option in different config file, only the first occurrence of the option is used.",
+          "x-intellij-html-description": "set GIT<em>DEFAULT</em>BRANCH, useful when dukkha can not detect branch name of origin/HEAD (e.g. github ci environment)  If your have multiple definitions of this option in different config file, only the first occurrence of the option is used."
         },
         "^default_git_branch@[^\\|]*!": {
           "$ref": "#/definitions/PatchSpec"
@@ -1069,7 +1069,31 @@
       "x-intellij-html-description": "a helper type to support rendering suffix for list of maps, used in Include/Exclude"
     },
     "arhat.dev.dukkha.pkg.renderer.echo.Driver": {},
-    "arhat.dev.dukkha.pkg.renderer.env.Driver": {},
+    "arhat.dev.dukkha.pkg.renderer.env.Driver": {
+      "properties": {
+        "enable_exec": {
+          "type": "boolean",
+          "description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. `$(do something)`) will fail",
+          "x-intellij-html-description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. <code>$(do something)</code>) will fail",
+          "default": false
+        }
+      },
+      "preferredOrder": [
+        "enable_exec"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^enable_exec@.*": {
+          "type": "boolean",
+          "description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. `$(do something)`) will fail",
+          "x-intellij-html-description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. <code>$(do something)</code>) will fail",
+          "default": false
+        },
+        "^enable_exec@[^\\|]*!": {
+          "$ref": "#/definitions/PatchSpec"
+        }
+      }
+    },
     "arhat.dev.dukkha.pkg.renderer.file.Driver": {
       "properties": {
         "cache_max_age": {

--- a/docs/generated/template_funcs.md
+++ b/docs/generated/template_funcs.md
@@ -305,7 +305,7 @@
 - `crypto.SHA512_256(interface {}) string`
 - `crypto.WPAPSK(interface {}, interface {}) (string, error)`
 - `dukkha.SetValue(string, interface {}) (interface {}, error)`
-- `eval.Env(interface {}) (string, error)`
+- `eval.Env(...interface {}) (string, error)`
 - `eval.Shell(interface {}, ...interface {}) (string, error)`
 - `eval.Template(interface {}) (string, error)`
 - `file.Exists(interface {}) bool`

--- a/docs/renderers/env.md
+++ b/docs/renderers/env.md
@@ -11,7 +11,12 @@ Generate field value by expanding environment variable references (`$env_name` o
 ```yaml
 renderers:
   # no options
-  env: {}
+  env:
+    # disable arbitrary command execution when expanding env if it is
+    # set to ture (e.g. `$(do something)` will error)
+    #
+    # Defaults to `true`
+    disable_exec: true
 ```
 
 ## Supported value types

--- a/pkg/renderer/env/driver.go
+++ b/pkg/renderer/env/driver.go
@@ -25,6 +25,14 @@ type Driver struct {
 	rs.BaseField `yaml:"-"`
 
 	name string
+
+	// EnableExec controls arbitrary command execution support when expanding env.
+	//
+	// if set to false, expanding env with shell evaluation (e.g. `$(do something)`)
+	// will fail
+	//
+	// Defaults to `false`
+	EnableExec *bool `yaml:"enable_exec"`
 }
 
 func (d *Driver) Init(ctx dukkha.ConfigResolvingContext) error {
@@ -47,7 +55,8 @@ func (d *Driver) RenderYaml(
 		)
 	}
 
-	ret, err := templateutils.ExpandEnv(rc, string(bytesToExpand))
+	enableExec := d.EnableExec != nil && *d.EnableExec
+	ret, err := templateutils.ExpandEnv(rc, string(bytesToExpand), enableExec)
 	if err != nil {
 		return nil, fmt.Errorf("renderer.%s: %w", d.name, err)
 	}

--- a/pkg/templateutils/eval.go
+++ b/pkg/templateutils/eval.go
@@ -54,9 +54,21 @@ func (ens *_evalNS) Template(tplData interface{}) (string, error) {
 	return string(buf.Next(buf.Len())), nil
 }
 
-// Env expands environment variables in textData
-// textData can be string or bytes
-func (ens *_evalNS) Env(textData interface{}, options ...string) (string, error) {
+// Env expands environment variables in last argument, which can be string or bytes
+// valid options before last argument are
+// `disable_exec` to deny shell evaluation (default behvior)
+// `enable_exec` to allow shell evaluation during expansing
+func (ens *_evalNS) Env(args ...interface{}) (string, error) {
+	var textData interface{}
+	switch len(args) {
+	case 0:
+		return "", nil
+	case 1:
+		textData = args[0]
+	default:
+		textData = args[len(args)-1]
+	}
+
 	var toExpand string
 	switch tt := textData.(type) {
 	case string:
@@ -68,7 +80,7 @@ func (ens *_evalNS) Env(textData interface{}, options ...string) (string, error)
 	}
 
 	enableExec := false
-	for _, opt := range options {
+	for _, opt := range args[:len(args)-1] {
 		switch opt {
 		case "disable_exec":
 			enableExec = false

--- a/pkg/templateutils/eval.go
+++ b/pkg/templateutils/eval.go
@@ -56,7 +56,7 @@ func (ens *_evalNS) Template(tplData interface{}) (string, error) {
 
 // Env expands environment variables in textData
 // textData can be string or bytes
-func (ens *_evalNS) Env(textData interface{}) (string, error) {
+func (ens *_evalNS) Env(textData interface{}, options ...string) (string, error) {
 	var toExpand string
 	switch tt := textData.(type) {
 	case string:
@@ -67,7 +67,17 @@ func (ens *_evalNS) Env(textData interface{}) (string, error) {
 		return "", fmt.Errorf("invalid non text data for expansion, got %T", tt)
 	}
 
-	return ExpandEnv(ens.rc, toExpand)
+	enableExec := false
+	for _, opt := range options {
+		switch opt {
+		case "disable_exec":
+			enableExec = false
+		case "enable_exec":
+			enableExec = true
+		}
+	}
+
+	return ExpandEnv(ens.rc, toExpand, enableExec)
 }
 
 // Shell evaluates scriptData as bash script, inputs as stdin streams (if any)


### PR DESCRIPTION
Deny arbitrary command execution by default, only accept shell evalution
when env renderer has `enable_exec` set to ture explicitly

Signed-off-by: donorp <donorp@arhat.solutions>
