### PR TITLE
fix(cmd|render): Fix chdir logic

### DIFF
--- a/cmd/dukkha/main_test.go
+++ b/cmd/dukkha/main_test.go
@@ -52,9 +52,21 @@ func TestRender(t *testing.T) {
 		return
 	}
 
+	wd, err := os.Getwd()
+	if !assert.NoError(t, err, "unable to get working dir") {
+		return
+	}
+
+	if !assert.True(t, filepath.IsAbs(wd), "working dir is not absolute path") {
+		return
+	}
+
 	for _, test := range testCases {
 		os.Args = sliceutils.NewStrings(baseArgs, "-f", test["format"])
 		main()
+		if !assert.NoError(t, os.Chdir(wd)) {
+			assert.FailNow(t, "unable to go back to original working dir")
+		}
 	}
 
 	entries, err := os.ReadDir(expectedDir)

--- a/docs/examples/arbitrary-file-rendering/README.md
+++ b/docs/examples/arbitrary-file-rendering/README.md
@@ -1,10 +1,48 @@
 # Arbitrary File Rendering
 
+Render any doc using rendering suffix
+
 ## Run
 
 ```bash
-# with jq
-dukkha render ./srouce -f json | jq '."foo"' -r
-# or with yq
-dukkha render ./source | yq '."foo"' -r
+dukkha render ./source -r
+```
+
+## Example output
+
+__NOTE:__ Depending on your host environment, some value may be different
+
+```yaml
+<!DOCTYPE html>
+<html>
+<body>
+  <p>Example a</p>
+  <p>Example b</p>
+  <p>Example c</p>
+  <p>Example d</p>
+</body>
+</html>
+---
+# Example Markdown Doc Generated In Yaml
+
+## Go Template
+
+Some value using go template `powerpc64le-linux-gnu`
+
+## Environment Variables
+
+Some value expanded from environment variable `master`
+---
+#!/bin/sh
+
+set -eux
+
+# shell evaluation in env renderer is disabled by default
+# we should get what we write as is
+foo="$(printf "%s" something)"
+
+export foo
+export current_host_kernel="darwin"
+export current_host_arch="arm64"
+
 ```

--- a/docs/examples/arbitrary-file-rendering/source/entrypoint.yaml
+++ b/docs/examples/arbitrary-file-rendering/source/entrypoint.yaml
@@ -1,1 +1,0 @@
-foo@file|template|env: templates/example.md

--- a/docs/examples/arbitrary-file-rendering/source/html.yaml
+++ b/docs/examples/arbitrary-file-rendering/source/html.yaml
@@ -1,0 +1,1 @@
+__@file|template|env: templates/example.html

--- a/docs/examples/arbitrary-file-rendering/source/markdown.yaml
+++ b/docs/examples/arbitrary-file-rendering/source/markdown.yaml
@@ -1,0 +1,1 @@
+__@file|template|env: templates/example.md

--- a/docs/examples/arbitrary-file-rendering/source/subdir/sh.yaml
+++ b/docs/examples/arbitrary-file-rendering/source/subdir/sh.yaml
@@ -1,0 +1,1 @@
+__@file|template|env: templates/example.sh

--- a/docs/examples/arbitrary-file-rendering/source/templates/example.html
+++ b/docs/examples/arbitrary-file-rendering/source/templates/example.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+{{- range $_, $v := split "a,b,c,d" "," }}
+  <p>Example {{ $v }}</p>
+{{- end }}
+</body>
+</html>

--- a/docs/examples/arbitrary-file-rendering/source/templates/example.md
+++ b/docs/examples/arbitrary-file-rendering/source/templates/example.md
@@ -2,8 +2,8 @@
 
 ## Go Template
 
-Some value using go template {{ getDebianTripleName "ppc64le" }}
+Some value using go template `{{ archconv.DebianTripleName "ppc64le" }}`
 
 ## Environment Variables
 
-Some value expanded from environment variable ${GIT_DEFAULT_BRANCH}
+Some value expanded from environment variable `${GIT_DEFAULT_BRANCH}`

--- a/docs/examples/arbitrary-file-rendering/source/templates/example.sh
+++ b/docs/examples/arbitrary-file-rendering/source/templates/example.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eux
+
+# shell evaluation in env renderer is disabled by default
+# we should get what we write as is
+foo="$(printf "%s" something)"
+
+export foo
+export current_host_kernel="{{ env.HOST_KERNEL }}"
+export current_host_arch="{{ env.HOST_ARCH }}"

--- a/docs/generated/schema.json
+++ b/docs/generated/schema.json
@@ -1153,8 +1153,8 @@
       "properties": {
         "enable_exec": {
           "type": "boolean",
-          "description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. `$(do something)`) will fail",
-          "x-intellij-html-description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. <code>$(do something)</code>) will fail",
+          "description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. `$(do something)`) will be skipped and formatted  NOTE: shell evaluation of backqouted string is always skipped and formatted",
+          "x-intellij-html-description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. <code>$(do something)</code>) will be skipped and formatted  NOTE: shell evaluation of backqouted string is always skipped and formatted",
           "default": false
         }
       },
@@ -1165,8 +1165,8 @@
       "patternProperties": {
         "^enable_exec@.*": {
           "type": "boolean",
-          "description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. `$(do something)`) will fail",
-          "x-intellij-html-description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. <code>$(do something)</code>) will fail",
+          "description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. `$(do something)`) will be skipped and formatted  NOTE: shell evaluation of backqouted string is always skipped and formatted",
+          "x-intellij-html-description": "controls arbitrary command execution support when expanding env.  if set to false, expanding env with shell evaluation (e.g. <code>$(do something)</code>) will be skipped and formatted  NOTE: shell evaluation of backqouted string is always skipped and formatted",
           "default": false
         },
         "^enable_exec@[^\\|]*!": {

--- a/docs/renderers/env.md
+++ b/docs/renderers/env.md
@@ -6,6 +6,8 @@ foo@env: some $ENV_NAME or ${REF} or $(shell command)
 
 Generate field value by expanding environment variable references (`$env_name` or `${env_name}`) and evaluating shell command (`$(some command)`).
 
+__NOTE:__ Backquoted string (e.g. <code>\`do something\`</code>) is not treated as shell evaluation, that's just plain text to this renderer.
+
 ## Config Options
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module arhat.dev/dukkha
 go 1.16
 
 require (
-	arhat.dev/pkg v0.7.4-0.20211107170734-2ed4d06a18d9
+	arhat.dev/pkg v0.7.4-0.20211109123634-b8f1f58f3c23
 	arhat.dev/rs v0.7.1-0.20211106175455-04fd26f5a52a
 	github.com/Masterminds/goutils v1.1.1
 	github.com/Masterminds/sprig/v3 v3.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 arhat.dev/pkg v0.7.3-0.20211031112332-ffefabe6bd30/go.mod h1:zPTNrA/tEoOUSpFQFyr7McM3LO8WQRhwNcULbcAM+ms=
 arhat.dev/pkg v0.7.3/go.mod h1:QmcFSZKUYOlgbtw6b0zDJXE3Fo4aJWDuS/6xg2imu/Y=
-arhat.dev/pkg v0.7.4-0.20211107170734-2ed4d06a18d9 h1:PRhCza6CmjTSlRmkrWlBypr5ol+WP6MaX0sma8gONzw=
-arhat.dev/pkg v0.7.4-0.20211107170734-2ed4d06a18d9/go.mod h1:QmcFSZKUYOlgbtw6b0zDJXE3Fo4aJWDuS/6xg2imu/Y=
+arhat.dev/pkg v0.7.4-0.20211109123634-b8f1f58f3c23 h1:DArRpOG/9/QwL1ELkytc4iI4gyUDTmvNfaoaQ7vkGiI=
+arhat.dev/pkg v0.7.4-0.20211109123634-b8f1f58f3c23/go.mod h1:QmcFSZKUYOlgbtw6b0zDJXE3Fo4aJWDuS/6xg2imu/Y=
 arhat.dev/rs v0.6.0/go.mod h1:surZ9C155JBuWQ0vflZamAccyxNpL9Fn/hRNUmoAYzQ=
 arhat.dev/rs v0.7.0/go.mod h1:sJXVt9WQKBYdyiOwxBWBvGOYoDPqljtvPgOZ6ira9Y0=
 arhat.dev/rs v0.7.1-0.20211106175455-04fd26f5a52a h1:jo2DOVcFxEpDe2siNl3ceMpKzkZFyrFYejuLh+ykfLc=

--- a/pkg/cmd/render/cmd.go
+++ b/pkg/cmd/render/cmd.go
@@ -2,29 +2,22 @@ package render
 
 import (
 	"fmt"
-	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 
-	"github.com/itchyny/gojq"
 	"github.com/spf13/cobra"
 
 	"arhat.dev/dukkha/pkg/dukkha"
 )
 
 func NewRenderCmd(ctx *dukkha.Context) *cobra.Command {
-	var (
-		outputFormat string
-		indentSize   int
-		indentStyle  string
-		recursive    bool
-		resultQuery  string
-
-		outputDests []string
-	)
+	// cli options
+	opts := &Options{}
 
 	renderCmd := &cobra.Command{
 		Use:           "render",
-		Short:         "Render your yaml docs",
+		Short:         "Render yaml docs using rendering suffix",
 		Args:          cobra.ArbitraryArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -35,100 +28,143 @@ func NewRenderCmd(ctx *dukkha.Context) *cobra.Command {
 		},
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var indentStr string
-			switch indentStyle {
-			case "space":
-				indentStr = " "
-			case "tab":
-				indentStr = "\t"
-			default:
-				indentStr = indentStyle
-			}
-
-			var query *gojq.Query
-			if len(resultQuery) != 0 {
-				var err error
-				query, err = gojq.Parse(resultQuery)
-				if err != nil {
-					return fmt.Errorf("invalid result query: %w", err)
-				}
-			}
-
-			var om map[string]*string
-			if len(outputDests) != 0 {
-				if len(outputDests) != len(args) {
-					return fmt.Errorf(
-						"number of output destination not matching sources: want %d, got %d",
-						len(args), len(outputDests),
-					)
-				}
-
-				om = make(map[string]*string)
-				for i := range outputDests {
-					src := args[i]
-
-					om[src] = &outputDests[i]
-				}
-			} else {
-				om = make(map[string]*string)
-				for _, src := range args {
-					om[src] = nil
-				}
-			}
-
-			var stdoutEnc encoder
-
-			createEncoder := func(w io.Writer) (encoder, error) {
-				if w == os.Stdout {
-					var err error
-					if stdoutEnc == nil {
-						stdoutEnc, err = newEncoder(
-							query, os.Stdout,
-							outputFormat, indentStr, indentSize,
-						)
-					}
-
-					return stdoutEnc, err
-				}
-
-				return newEncoder(query, w, outputFormat, indentStr, indentSize)
-			}
-
-			for _, src := range args {
-				err := renderYamlFileOrDir(
-					*ctx, src, om[src], outputFormat,
-					createEncoder,
-					recursive,
-					make(map[string]os.FileMode),
-				)
-				if err != nil {
-					return err
-				}
-			}
-
-			return nil
+			return run(*ctx, opts, args)
 		},
 	}
 
 	flags := renderCmd.Flags()
-	flags.StringSliceVarP(&outputDests, "output", "o", nil,
+	flags.StringSliceVarP(&opts.outputDests, "output", "o", nil,
 		"set output destionation for specified inputs (args)",
 	)
-	flags.StringVarP(&outputFormat, "output-format", "f", "yaml",
+	flags.StringVarP(&opts.outputFormat, "output-format", "f", "yaml",
 		"set output format, one of [json, yaml]",
 	)
-	flags.IntVarP(&indentSize, "indent-size", "n", 2,
+	flags.IntVarP(&opts.indentSize, "indent-size", "n", 2,
 		"set indent size",
 	)
-	flags.StringVarP(&indentStyle, "indent-style", "s", "space",
+	flags.StringVarP(&opts.indentStyle, "indent-style", "s", "space",
 		"set indent style, custom string or one of [space, tab]",
 	)
-	flags.BoolVarP(&recursive, "recursive", "r", false,
+	flags.BoolVarP(&opts.recursive, "recursive", "r", false,
 		"render directories recursively",
 	)
-	flags.StringVarP(&resultQuery, "query", "q", "",
+	flags.StringVarP(&opts.resultQuery, "query", "q", "",
 		"run jq style query over generated yaml/json docs before writing",
 	)
 
 	return renderCmd
+}
+
+func run(appCtx dukkha.Context, opts *Options, args []string) error {
+	resolvedOpts, err := opts.Resolve(args, os.Stdout)
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		// render yaml from stdin only
+		return renderYamlReader(
+			appCtx,
+			os.Stdin,
+			resolvedOpts.outputMapping["-"],
+			0664,
+			resolvedOpts,
+		)
+	}
+
+	originalWorkDir := appCtx.WorkingDir()
+	for _, src := range args {
+		if src == "-" {
+			err = renderYamlReader(
+				appCtx,
+				os.Stdin,
+				resolvedOpts.outputMapping["-"],
+				0664,
+				resolvedOpts,
+			)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		err = func() error {
+			var info fs.FileInfo
+			info, err = os.Stat(src)
+			if err != nil {
+				return err
+			}
+
+			// default values when src is a dir
+			var (
+				chdir      string
+				entrypoint string
+			)
+			if info.IsDir() {
+				// we are going to chdir into src dicrectory, or we
+				// have already been there
+				//
+				// so the entrypoint is always current dir
+				entrypoint = "."
+				chdir = src
+			} else {
+				// regular file
+				entrypoint = src
+				chdir = filepath.Dir(chdir)
+			}
+
+			chdir, err = filepath.Abs(chdir)
+			if err != nil {
+				return err
+			}
+
+			// chdir at the entrypoint (root of the source yaml)
+			// make relative paths in that dir happy
+
+			if chdir != originalWorkDir {
+				err = os.Chdir(chdir)
+				if err != nil {
+					return fmt.Errorf(
+						"chdir: going to source root %q: %w",
+						src, err,
+					)
+				}
+
+				// change DUKKHA_WORKING_DIR to make renderers like `shell`, `env` happy
+				appCtx.(interface {
+					OverrideWorkingDir(cwd string)
+				}).OverrideWorkingDir(chdir)
+
+				// always chdir back to original working dir, since other
+				// input source can be relative path to the original working dir
+				defer func() {
+					appCtx.(interface {
+						OverrideWorkingDir(cwd string)
+					}).OverrideWorkingDir(originalWorkDir)
+
+					err = os.Chdir(originalWorkDir)
+					if err != nil {
+						panic(fmt.Errorf(
+							"failed to go back to dukkha working dir: %w", err,
+						))
+					}
+				}()
+			}
+
+			return renderYamlFile(
+				appCtx,
+				entrypoint,
+				resolvedOpts.outputMapping[src],
+				resolvedOpts,
+				make(map[string]os.FileMode),
+			)
+		}()
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/cmd/render/cmd_opts.go
+++ b/pkg/cmd/render/cmd_opts.go
@@ -1,0 +1,107 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/itchyny/gojq"
+)
+
+type Options struct {
+	outputFormat string
+	indentSize   int
+	indentStyle  string
+	recursive    bool
+	resultQuery  string
+
+	outputDests []string
+}
+
+type ResolvedOptions struct {
+	indentStr string
+	query     *gojq.Query
+
+	outputMapping map[string]*string
+	createEncoder func(w io.Writer) (encoder, error)
+
+	outputFormat string
+	recursive    bool
+}
+
+func (opts *Options) Resolve(args []string, defaultOutputDest io.Writer) (*ResolvedOptions, error) {
+	ret := &ResolvedOptions{
+		outputMapping: make(map[string]*string),
+
+		outputFormat: opts.outputFormat,
+		recursive:    opts.recursive,
+	}
+
+	switch opts.indentStyle {
+	case "space":
+		ret.indentStr = " "
+	case "tab":
+		ret.indentStr = "\t"
+	default:
+		ret.indentStr = opts.indentStyle
+	}
+
+	if len(opts.resultQuery) != 0 {
+		var err error
+		ret.query, err = gojq.Parse(opts.resultQuery)
+		if err != nil {
+			return nil, fmt.Errorf("invalid result query: %w", err)
+		}
+	}
+
+	if len(opts.outputDests) != 0 {
+		switch {
+		case len(args) == 0 && len(opts.outputDests) != 1:
+			return nil, fmt.Errorf("only one destination can be set for stdin input")
+		case len(opts.outputDests) != len(args):
+			return nil, fmt.Errorf(
+				"number of output destination not matching sources: want %d, got %d",
+				len(args), len(opts.outputDests),
+			)
+		}
+
+		for i := range opts.outputDests {
+			src := args[i]
+
+			path, err := filepath.Abs(opts.outputDests[i])
+			if err != nil {
+				return nil, err
+			}
+
+			ret.outputMapping[src] = &path
+		}
+	} else {
+		if len(args) == 0 {
+			ret.outputMapping["-"] = nil
+		} else {
+			for _, src := range args {
+				ret.outputMapping[src] = nil
+			}
+		}
+	}
+
+	var stdoutEnc encoder
+
+	ret.createEncoder = func(w io.Writer) (encoder, error) {
+		if w == nil {
+			var err error
+			if stdoutEnc == nil {
+				stdoutEnc, err = newEncoder(
+					ret.query, defaultOutputDest,
+					opts.outputFormat, ret.indentStr, opts.indentSize,
+				)
+			}
+
+			return stdoutEnc, err
+		}
+
+		return newEncoder(ret.query, w, opts.outputFormat, ret.indentStr, opts.indentSize)
+	}
+
+	return ret, nil
+}

--- a/pkg/cmd/render/cmd_test.go
+++ b/pkg/cmd/render/cmd_test.go
@@ -1,0 +1,157 @@
+package render
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"arhat.dev/pkg/testhelper"
+	"arhat.dev/rs"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"arhat.dev/dukkha/pkg/constant"
+	"arhat.dev/dukkha/pkg/dukkha"
+	dukkha_test "arhat.dev/dukkha/pkg/dukkha/test"
+	"arhat.dev/dukkha/pkg/renderer/env"
+	"arhat.dev/dukkha/pkg/renderer/file"
+	"arhat.dev/dukkha/pkg/renderer/shell"
+	"arhat.dev/dukkha/pkg/sliceutils"
+)
+
+func TestCmd(t *testing.T) {
+
+	type TestSpec struct {
+		rs.BaseField
+
+		Options    []string `yaml:"options"`
+		BadOptions bool     `yaml:"bad_options"`
+
+		Sources   []string `yaml:"sources"`
+		BadSource bool     `yaml:"bad_source"`
+
+		OutputFiles []string `yaml:"output_files"`
+	}
+
+	type CheckSpec struct {
+		rs.BaseField
+
+		Expected string `yaml:"expected"`
+	}
+
+	testhelper.TestFixtures(t, "./fixtures",
+		func() interface{} { return rs.Init(&TestSpec{}, nil) },
+		func() interface{} { return rs.Init(&CheckSpec{}, nil) },
+		func(t *testing.T, in, c interface{}) {
+			spec := in.(*TestSpec)
+			check := c.(*CheckSpec)
+
+			cwd, err := os.Getwd()
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			defer t.Cleanup(func() {
+				if !assert.NoError(t, os.Chdir(cwd)) {
+					return
+				}
+			})
+
+			ctx := dukkha_test.NewTestContextWithGlobalEnv(t, context.TODO(), map[string]string{
+				constant.ENV_DUKKHA_WORKING_DIR: cwd,
+				constant.ENV_DUKKHA_CACHE_DIR:   filepath.Join(t.TempDir(), ".dukkha/cache"),
+			})
+			ctx.AddRenderer("file", file.NewDefault("file"))
+			ctx.AddRenderer("env", env.NewDefault("env"))
+			ctx.AddRenderer("shell", shell.NewDefault("shell"))
+			outputDir := filepath.Join(t.TempDir(), "output")
+			ctx.AddEnv(true, &dukkha.EnvEntry{
+				Name:  "out_dir",
+				Value: outputDir,
+			})
+
+			assert.NoError(t, os.MkdirAll(outputDir, 0755))
+
+			appCtx := dukkha.Context(ctx)
+			cmd := &cobra.Command{}
+			opts := &Options{}
+			createOptionsFlags(cmd, opts)
+
+			assert.NoError(t, spec.ResolveFields(ctx, -1))
+			err = cmd.ParseFlags(sliceutils.NewStrings(spec.Options, spec.Sources...))
+			if spec.BadOptions {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			stdout := &bytes.Buffer{}
+			err = run(appCtx, opts, spec.Sources, stdout)
+
+			if spec.BadSource {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if !assert.NoError(t, os.Chdir(cwd)) {
+				return
+			}
+
+			ctx.(interface {
+				OverrideWorkingDir(cwd string)
+			}).OverrideWorkingDir(cwd)
+
+			// have a look at the output dir
+			entries, err := os.ReadDir(outputDir)
+			assert.NoError(t, err)
+			t.Log(len(entries))
+			for _, v := range entries {
+				t.Log(v.Name())
+			}
+
+			var actual []*rs.AnyObject
+			for _, file := range spec.OutputFiles {
+				switch file {
+				case "-":
+					actualPart, err2 := parseYaml(yaml.NewDecoder(stdout))
+
+					assert.NoError(t, err2)
+
+					actual = append(actual, actualPart...)
+				default:
+					f, err2 := os.Open(file)
+					if !assert.NoError(t, err2) {
+						return
+					}
+
+					actualPart, err2 := parseYaml(yaml.NewDecoder(f))
+					_ = f.Close()
+
+					assert.NoError(t, err2)
+
+					actual = append(actual, actualPart...)
+				}
+			}
+
+			expected, err := parseYaml(yaml.NewDecoder(strings.NewReader(check.Expected)))
+			assert.NoError(t, err)
+
+			if !assert.Equal(t, len(expected), len(actual)) {
+				return
+			}
+
+			for i, v := range expected {
+				assert.NoError(t, v.ResolveFields(ctx, -1))
+
+				assert.EqualValues(t, v.NormalizedValue(), actual[i].NormalizedValue())
+			}
+		},
+	)
+}

--- a/pkg/cmd/render/fixtures/001-file.yaml
+++ b/pkg/cmd/render/fixtures/001-file.yaml
@@ -1,0 +1,15 @@
+options: []
+sources:
+- testdata/src.yaml
+bad_options: false
+bad_source: false
+output_files:
+- "-"
+---
+expected: |-
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/002-file-good-custom-chdir.yaml
+++ b/pkg/cmd/render/fixtures/002-file-good-custom-chdir.yaml
@@ -1,0 +1,16 @@
+options:
+- --chdir=testdata
+sources:
+- testdata/level-1/src.yaml
+bad_options: false
+bad_source: false
+output_files:
+- "-"
+---
+expected: |-
+  l1:top-file-data@file: testdata/data.txt
+  l1:l1-file-data@file: testdata/level-1/data.txt
+  l1:l2-file-data@file: testdata/level-1/level-2/data.txt
+  l1:top-shell-data@file: testdata/data.txt
+  l1:l1-shell-data@file: testdata/level-1/data.txt
+  l1:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/003-file-bad-default-chdir.yaml
+++ b/pkg/cmd/render/fixtures/003-file-bad-default-chdir.yaml
@@ -1,0 +1,7 @@
+options:
+# - --chdir=testdata/level-1
+sources:
+- testdata/level-1/src.yaml
+bad_options: false
+bad_source: true
+---

--- a/pkg/cmd/render/fixtures/004-file-output-to-dir-err.yaml
+++ b/pkg/cmd/render/fixtures/004-file-output-to-dir-err.yaml
@@ -1,0 +1,8 @@
+options@env:
+- -o=${out_dir}/
+sources:
+- testdata/src.yaml
+bad_options: false
+bad_source: true
+---
+# expected:

--- a/pkg/cmd/render/fixtures/005-file-output-to-file.yaml
+++ b/pkg/cmd/render/fixtures/005-file-output-to-file.yaml
@@ -1,0 +1,16 @@
+options@env:
+- -o=${out_dir}/test
+sources:
+- testdata/src.yaml
+bad_options: false
+bad_source: false
+output_files@env:
+- ${out_dir}/test
+---
+expected: |-
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/051-dir-non-recursive.yaml
+++ b/pkg/cmd/render/fixtures/051-dir-non-recursive.yaml
@@ -1,0 +1,15 @@
+options: []
+sources:
+- testdata
+bad_options: false
+bad_source: false
+output_files:
+- "-"
+---
+expected: |-
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/053-dir-non-recursive-output-to-dir.yaml
+++ b/pkg/cmd/render/fixtures/053-dir-non-recursive-output-to-dir.yaml
@@ -1,0 +1,16 @@
+options@env:
+- -o=${out_dir}/
+sources:
+- testdata
+bad_options: false
+bad_source: false
+output_files@env:
+- ${out_dir}/src.yaml
+---
+expected: |-
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/053-dir-non-recursive-output-to-non-existing-dir.yaml
+++ b/pkg/cmd/render/fixtures/053-dir-non-recursive-output-to-non-existing-dir.yaml
@@ -1,0 +1,16 @@
+options@env:
+- -o=${out_dir}/non-existing
+sources:
+- testdata
+bad_options: false
+bad_source: false
+output_files@env:
+- ${out_dir}/non-existing/src.yaml
+---
+expected: |-
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/061-dir-recursive.yaml
+++ b/pkg/cmd/render/fixtures/061-dir-recursive.yaml
@@ -1,0 +1,30 @@
+options:
+- -r
+sources:
+- testdata
+bad_options: false
+bad_source: false
+output_files:
+- "-"
+---
+expected: |-
+  l2:top-file-data@file: testdata/data.txt
+  l2:l1-file-data@file: testdata/level-1/data.txt
+  l2:l2-file-data@file: testdata/level-1/level-2/data.txt
+  l2:top-shell-data@file: testdata/data.txt
+  l2:l1-shell-data@file: testdata/level-1/data.txt
+  l2:l2-shell-data@file: testdata/level-1/level-2/data.txt
+  ---
+  l1:top-file-data@file: testdata/data.txt
+  l1:l1-file-data@file: testdata/level-1/data.txt
+  l1:l2-file-data@file: testdata/level-1/level-2/data.txt
+  l1:top-shell-data@file: testdata/data.txt
+  l1:l1-shell-data@file: testdata/level-1/data.txt
+  l1:l2-shell-data@file: testdata/level-1/level-2/data.txt
+  ---
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/062-dir-recursive-output-to-dir.yaml
+++ b/pkg/cmd/render/fixtures/062-dir-recursive-output-to-dir.yaml
@@ -1,0 +1,33 @@
+options@env:
+- -r
+- -o=${out_dir}/
+sources:
+- testdata
+bad_options: false
+bad_source: false
+output_files@env:
+- ${out_dir}/level-1/level-2/src.yaml
+- ${out_dir}/level-1/src.yaml
+- ${out_dir}/src.yaml
+---
+expected: |-
+  l2:top-file-data@file: testdata/data.txt
+  l2:l1-file-data@file: testdata/level-1/data.txt
+  l2:l2-file-data@file: testdata/level-1/level-2/data.txt
+  l2:top-shell-data@file: testdata/data.txt
+  l2:l1-shell-data@file: testdata/level-1/data.txt
+  l2:l2-shell-data@file: testdata/level-1/level-2/data.txt
+  ---
+  l1:top-file-data@file: testdata/data.txt
+  l1:l1-file-data@file: testdata/level-1/data.txt
+  l1:l2-file-data@file: testdata/level-1/level-2/data.txt
+  l1:top-shell-data@file: testdata/data.txt
+  l1:l1-shell-data@file: testdata/level-1/data.txt
+  l1:l2-shell-data@file: testdata/level-1/level-2/data.txt
+  ---
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/063-dir-recursive-output-to-non-existing-dir.yaml
+++ b/pkg/cmd/render/fixtures/063-dir-recursive-output-to-non-existing-dir.yaml
@@ -1,0 +1,33 @@
+options@env:
+- -r
+- -o=${out_dir}/non-existing
+sources:
+- testdata
+bad_options: false
+bad_source: false
+output_files@env:
+- ${out_dir}/non-existing/level-1/level-2/src.yaml
+- ${out_dir}/non-existing/level-1/src.yaml
+- ${out_dir}/non-existing/src.yaml
+---
+expected: |-
+  l2:top-file-data@file: testdata/data.txt
+  l2:l1-file-data@file: testdata/level-1/data.txt
+  l2:l2-file-data@file: testdata/level-1/level-2/data.txt
+  l2:top-shell-data@file: testdata/data.txt
+  l2:l1-shell-data@file: testdata/level-1/data.txt
+  l2:l2-shell-data@file: testdata/level-1/level-2/data.txt
+  ---
+  l1:top-file-data@file: testdata/data.txt
+  l1:l1-file-data@file: testdata/level-1/data.txt
+  l1:l2-file-data@file: testdata/level-1/level-2/data.txt
+  l1:top-shell-data@file: testdata/data.txt
+  l1:l1-shell-data@file: testdata/level-1/data.txt
+  l1:l2-shell-data@file: testdata/level-1/level-2/data.txt
+  ---
+  top:top-file-data@file: testdata/data.txt
+  top:l1-file-data@file: testdata/level-1/data.txt
+  top:l2-file-data@file: testdata/level-1/level-2/data.txt
+  top:top-shell-data@file: testdata/data.txt
+  top:l1-shell-data@file: testdata/level-1/data.txt
+  top:l2-shell-data@file: testdata/level-1/level-2/data.txt

--- a/pkg/cmd/render/fixtures/1001-err-output-count-mismatch-stdin.yaml
+++ b/pkg/cmd/render/fixtures/1001-err-output-count-mismatch-stdin.yaml
@@ -1,0 +1,9 @@
+options@env:
+- -o
+- ${out_dir}/data
+- -o
+- ${out_dir}/data
+sources: []
+bad_source: true
+---
+# expected:

--- a/pkg/cmd/render/fixtures/1002-err-output-count-mismatch-path.yaml
+++ b/pkg/cmd/render/fixtures/1002-err-output-count-mismatch-path.yaml
@@ -1,0 +1,10 @@
+options@env:
+- -o
+- ${out_dir}/data
+- -o
+- ${out_dir}/data
+sources:
+- testdata
+bad_source: true
+---
+# expected:

--- a/pkg/cmd/render/fixtures/1003-err-too-many-stdin-source.yaml
+++ b/pkg/cmd/render/fixtures/1003-err-too-many-stdin-source.yaml
@@ -1,0 +1,6 @@
+sources:
+- "-"
+- ""
+bad_source: true
+---
+# expected:

--- a/pkg/cmd/render/fixtures/1004-err-too-many-chdir-options.yaml
+++ b/pkg/cmd/render/fixtures/1004-err-too-many-chdir-options.yaml
@@ -1,0 +1,9 @@
+options@env:
+- --chdir
+- ${out_dir}/data
+- --chdir
+- ${out_dir}/data
+sources: []
+bad_source: true
+---
+# expected:

--- a/pkg/cmd/render/fixtures/101-file-query.yaml
+++ b/pkg/cmd/render/fixtures/101-file-query.yaml
@@ -1,0 +1,13 @@
+options:
+- |-
+  -q={foo: ."top:top-file-data", bar: "bar" }
+sources:
+- testdata/src.yaml
+bad_options: false
+bad_source: false
+output_files:
+- "-"
+---
+expected: |-
+  foo@file: testdata/data.txt
+  bar: bar

--- a/pkg/cmd/render/render_file.go
+++ b/pkg/cmd/render/render_file.go
@@ -18,7 +18,7 @@ func renderYamlFile(
 ) error {
 	sInfo, err := os.Stat(srcPath)
 	if err != nil {
-		return fmt.Errorf("failed to check src dir %q: %w", srcPath, err)
+		return fmt.Errorf("invalid file source: %w", err)
 	}
 
 	srcPerm[srcPath] = sInfo.Mode().Perm()
@@ -26,7 +26,7 @@ func renderYamlFile(
 	if sInfo.IsDir() {
 		entries, err2 := os.ReadDir(srcPath)
 		if err2 != nil {
-			return fmt.Errorf("failed to check files in src dir %q: %w", srcPath, err2)
+			return fmt.Errorf("unable to check files in src dir %q: %w", srcPath, err2)
 		}
 
 		for _, ent := range entries {

--- a/pkg/cmd/render/render_reader.go
+++ b/pkg/cmd/render/render_reader.go
@@ -1,0 +1,91 @@
+package render
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+
+	"arhat.dev/rs"
+	"go.uber.org/multierr"
+	"gopkg.in/yaml.v3"
+
+	"arhat.dev/dukkha/pkg/dukkha"
+)
+
+func renderYamlReader(
+	rc dukkha.Context,
+	src io.Reader,
+	destPath *string,
+	destPerm fs.FileMode,
+	opts *ResolvedOptions,
+) error {
+	dec := yaml.NewDecoder(src)
+	ret, err := parseYaml(dec)
+
+	// always write parsed yaml docs, regardless of errors
+
+	var enc encoder
+	if len(ret) != 0 {
+		if destPath == nil {
+			enc, err = opts.createEncoder(nil)
+			if err != nil {
+				return err
+			}
+		} else {
+			var destFile *os.File
+			destFile, err = os.OpenFile(
+				*destPath,
+				os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+				destPerm,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to open output file %q: %w",
+					*destPath, err,
+				)
+			}
+			defer func() { _ = destFile.Close() }()
+
+			enc, err = opts.createEncoder(destFile)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, doc := range ret {
+		err2 := doc.ResolveFields(rc, -1)
+		if err2 != nil {
+			return multierr.Append(err, err2)
+		}
+
+		err2 = enc.Encode(doc)
+		if err2 != nil {
+			return multierr.Append(err, err2)
+		}
+	}
+
+	return err
+}
+
+func parseYaml(dec *yaml.Decoder) ([]*rs.AnyObject, error) {
+	var ret []*rs.AnyObject
+	for {
+		obj := &rs.AnyObject{}
+		err := dec.Decode(obj)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return ret, nil
+			}
+
+			return ret, err
+		}
+
+		if obj == nil {
+			continue
+		}
+
+		ret = append(ret, obj)
+	}
+}

--- a/pkg/cmd/render/testdata/data.txt
+++ b/pkg/cmd/render/testdata/data.txt
@@ -1,0 +1,1 @@
+top-level-test-data

--- a/pkg/cmd/render/testdata/level-1/data.txt
+++ b/pkg/cmd/render/testdata/level-1/data.txt
@@ -1,0 +1,1 @@
+level-2-test-data

--- a/pkg/cmd/render/testdata/level-1/level-2/data.txt
+++ b/pkg/cmd/render/testdata/level-1/level-2/data.txt
@@ -1,0 +1,1 @@
+level-2-test-data

--- a/pkg/cmd/render/testdata/level-1/level-2/script.sh
+++ b/pkg/cmd/render/testdata/level-1/level-2/script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+foo="$(<level-1/level-2/data.txt)"
+echo "${foo}"

--- a/pkg/cmd/render/testdata/level-1/level-2/src.yaml
+++ b/pkg/cmd/render/testdata/level-1/level-2/src.yaml
@@ -1,0 +1,7 @@
+l2:top-file-data@file: data.txt
+l2:l1-file-data@file: level-1/data.txt
+l2:l2-file-data@file: level-1/level-2/data.txt
+
+l2:top-shell-data@file|shell: script.sh
+l2:l1-shell-data@file|shell: level-1/script.sh
+l2:l2-shell-data@file|shell: level-1/level-2/script.sh

--- a/pkg/cmd/render/testdata/level-1/script.sh
+++ b/pkg/cmd/render/testdata/level-1/script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+foo="$(<level-1/data.txt)"
+echo "${foo}"

--- a/pkg/cmd/render/testdata/level-1/src.yaml
+++ b/pkg/cmd/render/testdata/level-1/src.yaml
@@ -1,0 +1,7 @@
+l1:top-file-data@file: data.txt
+l1:l1-file-data@file: level-1/data.txt
+l1:l2-file-data@file: level-1/level-2/data.txt
+
+l1:top-shell-data@file|shell: script.sh
+l1:l1-shell-data@file|shell: level-1/script.sh
+l1:l2-shell-data@file|shell: level-1/level-2/script.sh

--- a/pkg/cmd/render/testdata/script.sh
+++ b/pkg/cmd/render/testdata/script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+foo="$(<data.txt)"
+echo "${foo}"

--- a/pkg/cmd/render/testdata/src.yaml
+++ b/pkg/cmd/render/testdata/src.yaml
@@ -1,0 +1,7 @@
+top:top-file-data@file: data.txt
+top:l1-file-data@file: level-1/data.txt
+top:l2-file-data@file: level-1/level-2/data.txt
+
+top:top-shell-data@file|shell: script.sh
+top:l1-shell-data@file|shell: level-1/script.sh
+top:l2-shell-data@file|shell: level-1/level-2/script.sh

--- a/pkg/dukkha/rendering_values.go
+++ b/pkg/dukkha/rendering_values.go
@@ -138,6 +138,12 @@ func (c *envValues) OverrideDefaultGitBranch(branch string) {
 	c.globalEnv[constant.ENV_GIT_DEFAULT_BRANCH] = branch
 }
 
+// OverrideWorkingDir set DUKKHA_WORKING_DIR to cwd
+// should not be exposed by any interface type in this package
+func (c *envValues) OverrideWorkingDir(cwd string) {
+	c.globalEnv[constant.ENV_DUKKHA_WORKING_DIR] = cwd
+}
+
 func (c *envValues) WorkingDir() string {
 	return c.globalEnv[constant.ENV_DUKKHA_WORKING_DIR]
 }

--- a/pkg/renderer/env/driver.go
+++ b/pkg/renderer/env/driver.go
@@ -29,7 +29,9 @@ type Driver struct {
 	// EnableExec controls arbitrary command execution support when expanding env.
 	//
 	// if set to false, expanding env with shell evaluation (e.g. `$(do something)`)
-	// will fail
+	// will be skipped and formatted
+	//
+	// NOTE: shell evaluation of backqouted string is always skipped and formatted
 	//
 	// Defaults to `false`
 	EnableExec *bool `yaml:"enable_exec"`

--- a/pkg/renderer/env/driver_test.go
+++ b/pkg/renderer/env/driver_test.go
@@ -67,17 +67,22 @@ func TestDriver_Render(t *testing.T) {
 			enableExec: &vTrue,
 		},
 		{
-			name:       "Invalid Shell Evaluation When Exec Disabled Explicitly",
+			name:       "Ignored Shell Evaluation When Exec Disabled Explicitly",
 			rawData:    "foo $(echo hello)",
-			errStr:     "unexpected command substitution",
+			expected:   "foo $(echo hello)",
 			enableExec: &vFalse,
 		},
 		{
-			name:       "Invalid Shell Evaluation When Exec Disabled Implicitly",
+			name:       "Ignored Shell Evaluation When Exec Disabled Implicitly",
 			rawData:    "foo $(echo hello)",
-			expected:   "foo hello",
-			errStr:     "unexpected command substitution",
+			expected:   "foo $(echo hello)",
 			enableExec: nil,
+		},
+		{
+			name:       "Always ignored backquoted shell evaluation",
+			rawData:    "foo `echo hello` $(echo hello)",
+			expected:   "foo `echo hello` hello",
+			enableExec: &vTrue,
 		},
 		{
 			name:       "Valid Shell Evaluation With Round Brackets",

--- a/vendor/arhat.dev/pkg/testhelper/hijack.go
+++ b/vendor/arhat.dev/pkg/testhelper/hijack.go
@@ -1,0 +1,46 @@
+package testhelper
+
+import (
+	"os"
+	"syscall"
+)
+
+func HijackStandardStreams(stdin, stdout, stderr *os.File, do func()) {
+	if stdout != nil {
+		originalStdout := os.Stdout
+		originalStdoutFD := syscall.Stdout
+		defer func() {
+			os.Stdout = originalStdout
+			syscall.Stdout = originalStdoutFD
+		}()
+
+		os.Stdout = stdout
+		syscall.Stdout = getSyscallFD(uintptr(stdout.Fd()))
+	}
+
+	if stderr != nil {
+		originalStderr := os.Stderr
+		originalStderrFD := syscall.Stderr
+		defer func() {
+			os.Stderr = originalStderr
+			syscall.Stderr = originalStderrFD
+		}()
+
+		os.Stderr = stderr
+		syscall.Stderr = getSyscallFD(uintptr(stderr.Fd()))
+	}
+
+	if stdin != nil {
+		originalStdin := os.Stdin
+		originalStdinFD := syscall.Stdin
+		defer func() {
+			os.Stdin = originalStdin
+			syscall.Stdin = originalStdinFD
+		}()
+
+		os.Stdin = stdin
+		syscall.Stdin = getSyscallFD(uintptr(stdin.Fd()))
+	}
+
+	do()
+}

--- a/vendor/arhat.dev/pkg/testhelper/hijack_unix.go
+++ b/vendor/arhat.dev/pkg/testhelper/hijack_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package testhelper
+
+func getSyscallFD(fd uintptr) int {
+	return int(fd)
+}

--- a/vendor/arhat.dev/pkg/testhelper/hijack_windows.go
+++ b/vendor/arhat.dev/pkg/testhelper/hijack_windows.go
@@ -1,0 +1,9 @@
+package testhelper
+
+import (
+	"syscall"
+)
+
+func getSyscallFD(fd uintptr) syscall.Handle {
+	return syscall.Handle(fd)
+}

--- a/vendor/arhat.dev/pkg/testhelper/io.go
+++ b/vendor/arhat.dev/pkg/testhelper/io.go
@@ -1,6 +1,8 @@
 package testhelper
 
-import "io"
+import (
+	"io"
+)
 
 // NewAlwaysFailReader creates an reader already fail on Read() call
 // with provided err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# arhat.dev/pkg v0.7.4-0.20211107170734-2ed4d06a18d9
+# arhat.dev/pkg v0.7.4-0.20211109123634-b8f1f58f3c23
 ## explicit
 arhat.dev/pkg/envhelper
 arhat.dev/pkg/exechelper


### PR DESCRIPTION
* Only change working directory at entrypoint
* Update env renderer behaivor for shell evaluation:
  - Always treat backquoted string as plain text
  - Sliently keep original evaluation text when command execution
    is disabled
* Update doc example for arbitrary file rendering using virtual key

Signed-off-by: donorp <donorp@arhat.solutions>
